### PR TITLE
User foto management/accept decline

### DIFF
--- a/backend/models.js
+++ b/backend/models.js
@@ -4,3 +4,4 @@ require('./models/role');
 require('./models/user');
 require('./models/newsArticle');
 require('./models/image');
+require('./models/userImage');

--- a/backend/repository/userImage.js
+++ b/backend/repository/userImage.js
@@ -3,7 +3,7 @@ const UserImage = mongoose.model('UserImage');
 
 module.exports = {
     async getUserImageById(id) {
-        return await UserImage.findById(id)
+        return await UserImage.findById({ $eq: id })
             .catch(err => console.log(`Cannot find user image by id ${id} in UserImage dataset.`, err));
     },
     async createUserImage(image) {

--- a/backend/repository/userImage.js
+++ b/backend/repository/userImage.js
@@ -21,6 +21,10 @@ module.exports = {
         return await UserImage.findOneAndUpdate({ _id: { $eq: userImage.id } }, { approvalStatus: 'declined' }, { new: true })
             .catch(err => console.error(err));
     },
+    async restoreUserImage(userImage) {
+        return await UserImage.findOneAndUpdate({ _id: { $eq: userImage.id } }, { approvalStatus: 'pending' }, { new: true })
+            .catch(err => console.error(err));
+    },
     async deleteUserImage(userImage) {
         return await UserImage.deleteOne(userImage)
             .catch(err => console.error(err));

--- a/backend/repository/userImage.js
+++ b/backend/repository/userImage.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+const UserImage = mongoose.model('UserImage');
+
+module.exports = {
+    async getUserImageById(id) {
+        return await UserImage.findById(id)
+            .catch(err => console.log(`Cannot find user image by id ${id} in UserImage dataset.`, err));
+    },
+    async createUserImage(image) {
+        await image.save();
+
+        const userImage = new UserImage({ image: image._id });
+
+        await userImage.save();
+    },
+    async approveUserImage(userImage) {
+        return await UserImage.findOneAndUpdate({ _id: { $eq: userImage.id } }, { approvalStatus: 'approved' }, { new: true })
+            .catch(err => console.error(err));
+    },
+    async declineUserImage(userImage) {
+        return await UserImage.findOneAndUpdate({ _id: { $eq: userImage.id } }, { approvalStatus: 'declined' }, { new: true })
+            .catch(err => console.error(err));
+    },
+    async deleteUserImage(userImage) {
+        return await UserImage.deleteOne(userImage)
+            .catch(err => console.error(err));
+    }
+};

--- a/backend/routes/api/userImage/approve.js
+++ b/backend/routes/api/userImage/approve.js
@@ -16,7 +16,7 @@ router.post('/', async (req, res) => {
             res.status(500).send(`Could not approve user image.`);
         }
     } catch (err) {
-        res.status(500).send(`Could not approve user image: ${err}`);
+        res.status(500).send(`Could not approve user image: ` + err);
     }
 });
 

--- a/backend/routes/api/userImage/approve.js
+++ b/backend/routes/api/userImage/approve.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getUserImageById, approveUserImage } = require('../../../repository/userImage');
+
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+    const { id } = req.body;
+
+    try {
+        const userImage = await getUserImageById(id);
+        if (userImage) {
+            await approveUserImage(userImage);
+            res.status(200).send(`User image approved successfully!`);
+        } else {
+            res.status(500).send(`Could not approve user image.`);
+        }
+    } catch (err) {
+        res.status(500).send(`Could not approve user image: ${err}`);
+    }
+});
+
+module.exports = router;

--- a/backend/routes/api/userImage/create.js
+++ b/backend/routes/api/userImage/create.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const { createUserImage } = require('../../../repository/userImage');
+
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+    const { image } = req.body;
+
+    try {
+        await createUserImage(image);
+        res.status(200).send(`User image created successfully!`);
+    } catch (err) {
+        res.status(500).send(`Could not create user image: ${err}`);
+    }
+});
+
+module.exports = router;

--- a/backend/routes/api/userImage/create.js
+++ b/backend/routes/api/userImage/create.js
@@ -7,18 +7,18 @@ const Image = mongoose.model('Image');
 router.use(express.json());
 
 router.post('/', async (req, res) => {
-    const { image } = req.body;
-    const { name, data, contentType } = image;
-
-    const newImage = new Image({
-        name, data, contentType
-    });
-
     try {
+        const { image } = req.body;
+        const { name, data, contentType } = image;
+    
+        const newImage = new Image({
+            name, data, contentType
+        });
+
         await createUserImage(newImage);
         res.status(200).send(`User image created successfully!`);
     } catch (err) {
-        res.status(500).send(`Could not create user image: ${err}`);
+        res.status(500).send(`Could not create user image: ` + err);
     }
 });
 

--- a/backend/routes/api/userImage/create.js
+++ b/backend/routes/api/userImage/create.js
@@ -1,14 +1,21 @@
 const express = require('express');
+const mongoose = require('mongoose');
 const router = express.Router();
 const { createUserImage } = require('../../../repository/userImage');
+const Image = mongoose.model('Image');
 
 router.use(express.json());
 
 router.post('/', async (req, res) => {
     const { image } = req.body;
+    const { name, data, contentType } = image;
+
+    const newImage = new Image({
+        name, data, contentType
+    });
 
     try {
-        await createUserImage(image);
+        await createUserImage(newImage);
         res.status(200).send(`User image created successfully!`);
     } catch (err) {
         res.status(500).send(`Could not create user image: ${err}`);

--- a/backend/routes/api/userImage/decline.js
+++ b/backend/routes/api/userImage/decline.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getUserImageById, declineUserImage } = require('../../../repository/userImage');
+
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+    const { id } = req.body;
+
+    try {
+        const userImage = await getUserImageById(id);
+        if (userImage) {
+            await declineUserImage(userImage);
+            res.status(200).send(`User image declined successfully!`);
+        } else {
+            res.status(500).send(`Could not decline user image.`);
+        }
+    } catch (err) {
+        res.status(500).send(`Could not decline user image: ${err}`);
+    }
+});
+
+module.exports = router;

--- a/backend/routes/api/userImage/decline.js
+++ b/backend/routes/api/userImage/decline.js
@@ -16,7 +16,7 @@ router.post('/', async (req, res) => {
             res.status(500).send(`Could not decline user image.`);
         }
     } catch (err) {
-        res.status(500).send(`Could not decline user image: ${err}`);
+        res.status(500).send(`Could not decline user image: ` + err);
     }
 });
 

--- a/backend/routes/api/userImage/delete.js
+++ b/backend/routes/api/userImage/delete.js
@@ -10,8 +10,12 @@ router.post('/', async (req, res) => {
     try {
         const userImage = await getUserImageById(id);
         if (userImage) {
-            await deleteUserImage(userImage);
-            res.status(200).send(`User image deleted successfully!`);
+            if (userImage.approvalStatus === 'declined') {
+                await deleteUserImage(userImage);
+                res.status(200).send(`User image deleted successfully!`);
+            } else {
+                res.status(500).send(`Could not delete user image: is not declined`);
+            }
         } else {
             res.status(500).send(`Could not delete user image.`);
         }

--- a/backend/routes/api/userImage/delete.js
+++ b/backend/routes/api/userImage/delete.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getUserImageById, deleteUserImage } = require('../../../repository/userImage');
+
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+    const { id } = req.body;
+
+    try {
+        const userImage = await getUserImageById(id);
+        if (userImage) {
+            await deleteUserImage(userImage);
+            res.status(200).send(`User image deleted successfully!`);
+        } else {
+            res.status(500).send(`Could not delete user image.`);
+        }
+    } catch (err) {
+        res.status(500).send(`Could not delete user image: ${err}`);
+    }
+});
+
+module.exports = router;

--- a/backend/routes/api/userImage/delete.js
+++ b/backend/routes/api/userImage/delete.js
@@ -16,7 +16,7 @@ router.post('/', async (req, res) => {
             res.status(500).send(`Could not delete user image.`);
         }
     } catch (err) {
-        res.status(500).send(`Could not delete user image: ${err}`);
+        res.status(500).send(`Could not delete user image: ` + err);
     }
 });
 

--- a/backend/routes/api/userImage/index.js
+++ b/backend/routes/api/userImage/index.js
@@ -7,6 +7,7 @@ router.use(express.json());
 router.use('/create', require('./create'));
 router.use('/approve', require('./approve'));
 router.use('/decline', require('./decline'));
+router.use('/restore', require('./restore'));
 router.use('/delete', require('./delete'));
 
 module.exports = router;

--- a/backend/routes/api/userImage/index.js
+++ b/backend/routes/api/userImage/index.js
@@ -1,13 +1,14 @@
 const express = require('express');
+const { authenticateToken } = require('../../../middlewares/auth');
 
 const router = express.Router();
 
 router.use(express.json());
 
 router.use('/create', require('./create'));
-router.use('/approve', require('./approve'));
-router.use('/decline', require('./decline'));
-router.use('/restore', require('./restore'));
-router.use('/delete', require('./delete'));
+router.use('/approve', authenticateToken, require('./approve'));
+router.use('/decline', authenticateToken, require('./decline'));
+router.use('/restore', authenticateToken, require('./restore'));
+router.use('/delete', authenticateToken, require('./delete'));
 
 module.exports = router;

--- a/backend/routes/api/userImage/index.js
+++ b/backend/routes/api/userImage/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.use(express.json());
+
+router.use('/create', require('./create'));
+router.use('/approve', require('./approve'));
+router.use('/decline', require('./decline'));
+router.use('/delete', require('./delete'));
+
+module.exports = router;

--- a/backend/routes/api/userImage/restore.js
+++ b/backend/routes/api/userImage/restore.js
@@ -16,7 +16,7 @@ router.post('/', async (req, res) => {
             res.status(500).send(`Could not restore user image.`);
         }
     } catch (err) {
-        res.status(500).send(`Could not restore user image: ${err}`);
+        res.status(500).send(`Could not restore user image: ` + err);
     }
 });
 

--- a/backend/routes/api/userImage/restore.js
+++ b/backend/routes/api/userImage/restore.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getUserImageById, restoreUserImage } = require('../../../repository/userImage');
+
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+    const { id } = req.body;
+
+    try {
+        const userImage = await getUserImageById(id);
+        if (userImage) {
+            await restoreUserImage(userImage);
+            res.status(200).send(`User image restored successfully!`);
+        } else {
+            res.status(500).send(`Could not restore user image.`);
+        }
+    } catch (err) {
+        res.status(500).send(`Could not restore user image: ${err}`);
+    }
+});
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -21,4 +21,6 @@ router.use('/api/user/get-list', require('./api/user/getList'));
 router.use('/api/authToken', require('./api/authToken'));
 router.use('/api/news-article', requestLimiter, require('./api/newsArticle'));
 
+router.use('/api/userImage', require('./api/userImage'));
+
 module.exports = router;


### PR DESCRIPTION
# Description

User images can now be managed:
- Creating
- Approving
- Declining
- Restoring
- Deleting

## Type of change

Please delete options that are not relevant and add new options if necessary. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Teststappenplan

1. Voer `npm install` en `npm run dev` uit.
2. Maak een UserImage aan via Postman met de route `/api/userImage/create`. Geef een body mee met een image (voorbeeld onderaan).
3. Test de routes `/api/userImage/approve`, `/api/userImage/decline` en `/api/userImage/restore` met als body een UserImage _id.
4. Test eventueel ook `/api/userImage/delete` met een UserImage _id.



**Voorbeeld van body voor `/create`:**
```
{
    "image": {
        "name": "TestUserImage",
        "data": "BASE64 DATA",
        "contentType": "image/jpeg"
    }
}
```
Om base64 data te krijgen, gebruik een online converter zoals [Base64 Guru](https://base64.guru/converter/encode/image).



**Voorbeeld van body voor de overige routes:**
```
{
    "id": "MongoDB _id"
}
```
Om een MongoDB _id te krijgen, kopieer 'm gewoon van de database.